### PR TITLE
Issue-15: Fix strings becoming base64 encoding after conversion

### DIFF
--- a/src/main/java/io/github/adrianulbona/osm/parquet/convertor/NodeWriteSupport.java
+++ b/src/main/java/io/github/adrianulbona/osm/parquet/convertor/NodeWriteSupport.java
@@ -3,13 +3,13 @@ package io.github.adrianulbona.osm.parquet.convertor;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.Types;
 import org.openstreetmap.osmosis.core.domain.v0_6.Node;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
-import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 
 
 /**
@@ -22,8 +22,8 @@ public class NodeWriteSupport extends OsmEntityWriteSupport<Node> {
 
     public NodeWriteSupport(boolean excludeMetadata) {
         super(excludeMetadata);
-        latType = new PrimitiveType(REQUIRED, DOUBLE, "latitude");
-        longType = new PrimitiveType(REQUIRED, DOUBLE, "longitude");
+        latType = Types.required(DOUBLE).named("latitude");
+        longType = Types.required(DOUBLE).named("longitude");
     }
 
     @Override

--- a/src/main/java/io/github/adrianulbona/osm/parquet/convertor/OsmEntityWriteSupport.java
+++ b/src/main/java/io/github/adrianulbona/osm/parquet/convertor/OsmEntityWriteSupport.java
@@ -4,10 +4,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.parquet.hadoop.api.WriteSupport;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.io.api.RecordConsumer;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.*;
 import org.openstreetmap.osmosis.core.domain.v0_6.Entity;
 import org.openstreetmap.osmosis.core.domain.v0_6.Tag;
 
@@ -16,8 +13,8 @@ import java.util.LinkedList;
 import java.util.List;
 
 import static java.util.Arrays.asList;
+import static org.apache.parquet.schema.LogicalTypeAnnotation.*;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.*;
-import static org.apache.parquet.schema.Type.Repetition.*;
 
 
 /**
@@ -40,15 +37,15 @@ public abstract class OsmEntityWriteSupport<E extends Entity> extends WriteSuppo
     protected RecordConsumer recordConsumer;
 
     public OsmEntityWriteSupport(boolean excludeMetadata) {
-        idType = new PrimitiveType(REQUIRED, INT64, "id");
-        tagKeyType = new PrimitiveType(REQUIRED, BINARY, "key");
-        tagValueType = new PrimitiveType(OPTIONAL, BINARY, "value");
-        tags = new GroupType(REPEATED, "tags", tagKeyType, tagValueType);
-        versionType = new PrimitiveType(OPTIONAL, INT32, "version");
-        timestampType = new PrimitiveType(OPTIONAL, INT64, "timestamp");
-        changesetType = new PrimitiveType(OPTIONAL, INT64, "changeset");
-        uidType = new PrimitiveType(OPTIONAL, INT32, "uid");
-        userSidType = new PrimitiveType(OPTIONAL, BINARY, "user_sid");
+        idType = Types.required(INT64).named("id");
+        tagKeyType = Types.required(BINARY).as(stringType()).named("key");
+        tagValueType = Types.optional(BINARY).as(stringType()).named("value");
+        tags = Types.repeatedGroup().addFields(tagKeyType, tagValueType).named("tags");
+        versionType = Types.optional(INT32).named("version");
+        timestampType = Types.optional(INT64).named("timestamp");
+        changesetType = Types.optional(INT64).named("changeset");
+        uidType = Types.optional(INT32).named("uid");
+        userSidType = Types.optional(BINARY).as(stringType()).named("user_sid");
         this.excludeMetadata = excludeMetadata;
     }
 

--- a/src/main/java/io/github/adrianulbona/osm/parquet/convertor/RelationWriteSupport.java
+++ b/src/main/java/io/github/adrianulbona/osm/parquet/convertor/RelationWriteSupport.java
@@ -1,19 +1,15 @@
 package io.github.adrianulbona.osm.parquet.convertor;
 
 import org.apache.parquet.io.api.Binary;
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.*;
 import org.openstreetmap.osmosis.core.domain.v0_6.Relation;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.apache.parquet.schema.LogicalTypeAnnotation.*;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.BINARY;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.apache.parquet.schema.Type.Repetition.REPEATED;
-import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 
 
 /**
@@ -28,10 +24,10 @@ public class RelationWriteSupport extends OsmEntityWriteSupport<Relation> {
 
     public RelationWriteSupport(boolean excludeMetadata) {
         super(excludeMetadata);
-        memberIdType = new PrimitiveType(REQUIRED, INT64, "id");
-        memberRoleType = new PrimitiveType(REQUIRED, BINARY, "role");
-        memberTypeType = new PrimitiveType(REQUIRED, BINARY, "type");
-        membersType = new GroupType(REPEATED, "members", memberIdType, memberRoleType, memberTypeType);
+        memberIdType = Types.required(INT64).named("id");
+        memberRoleType = Types.required(BINARY).as(stringType()).named("role");
+        memberTypeType = Types.required(BINARY).as(stringType()).named("type");
+        membersType = Types.repeatedGroup().addFields(memberIdType, memberRoleType, memberTypeType).named("members");
     }
 
     @Override

--- a/src/main/java/io/github/adrianulbona/osm/parquet/convertor/WayWriteSupport.java
+++ b/src/main/java/io/github/adrianulbona/osm/parquet/convertor/WayWriteSupport.java
@@ -1,9 +1,6 @@
 package io.github.adrianulbona.osm.parquet.convertor;
 
-import org.apache.parquet.schema.GroupType;
-import org.apache.parquet.schema.MessageType;
-import org.apache.parquet.schema.PrimitiveType;
-import org.apache.parquet.schema.Type;
+import org.apache.parquet.schema.*;
 import org.openstreetmap.osmosis.core.domain.v0_6.Way;
 import org.openstreetmap.osmosis.core.domain.v0_6.WayNode;
 
@@ -15,8 +12,6 @@ import java.util.Map;
 import static java.util.stream.IntStream.range;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT32;
 import static org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName.INT64;
-import static org.apache.parquet.schema.Type.Repetition.REPEATED;
-import static org.apache.parquet.schema.Type.Repetition.REQUIRED;
 
 
 /**
@@ -30,9 +25,9 @@ public class WayWriteSupport extends OsmEntityWriteSupport<Way> {
 
     public WayWriteSupport(boolean excludeMetadata) {
         super(excludeMetadata);
-        nodeIndexType = new PrimitiveType(REQUIRED, INT32, "index");
-        nodeIdType = new PrimitiveType(REQUIRED, INT64, "nodeId");
-        nodes = new GroupType(REPEATED, "nodes", nodeIndexType, nodeIdType);
+        nodeIndexType = Types.required(INT32).named("index");
+        nodeIdType = Types.required(INT64).named("nodeId");
+        nodes = Types.repeatedGroup().addFields(nodeIndexType, nodeIdType).named("nodes");
     }
 
     @Override


### PR DESCRIPTION
Tring to fix https://github.com/adrianulbona/osm-parquetizer/issues/15
Along with it, changed to the native way - use Type builder -for creating `PrimitiveType` and `GroupType` objects.